### PR TITLE
Fix link in the top header.

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -51,7 +51,8 @@ Pandoc, converting HTML to Org-mode."
                                 :link url
                                 :description title
                                 :orglink orglink
-                                :initial (buffer-string)))
+                                :initial (buffer-string)
+				:annotation (org-make-link-string url title))))
         (raise-frame)
         (funcall 'org-capture nil template)
 


### PR DESCRIPTION
When I capture something, the header is empty instead of containing a link to the website. This fixes it.