### PR TITLE
Fix package

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -1,4 +1,4 @@
-;;; org-protocol-capture-html --- Capture HTML with org-protocol
+;;; org-protocol-capture-html.el --- Capture HTML with org-protocol
 
 ;;; Commentary:
 
@@ -140,4 +140,4 @@ Pandoc, converting HTML to Org-mode."
 
 (provide 'org-protocol-capture-html)
 
-;;; org-protocol-capture-html ends here
+;;; org-protocol-capture-html.el ends here

--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -1,5 +1,7 @@
 ;;; org-protocol-capture-html.el --- Capture HTML with org-protocol
 
+;; Package-Requires: ((emacs "24.4"))
+
 ;;; Commentary:
 
 ;; This package captures Web pages into Org-mode using Pandoc to
@@ -12,6 +14,10 @@
 ;; for instructions.
 
 ;;; Code:
+
+(require 'org)
+(require 'org-protocol)
+(require 'subr-x)
 
 ;;;; Direct-to-Pandoc
 

--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -18,6 +18,7 @@
 (require 'org)
 (require 'org-protocol)
 (require 'subr-x)
+(require 'cl-lib)
 
 ;;;; Direct-to-Pandoc
 
@@ -41,10 +42,10 @@ Pandoc, converting HTML to Org-mode."
 	 (type (if (string-match "^\\([a-z]+\\):" url)
 		   (match-string 1 url)))
 	 (title (or (string-trim (cadr parts)) ""))
-	 (content (or (string-trim (caddr parts)) ""))
+	 (content (or (string-trim (cl-caddr parts)) ""))
 	 (orglink (org-make-link-string
 		   url (if (string-match "[^[:space:]]" title) title url)))
-	 (query (or (org-protocol-convert-query-to-plist (cadddr parts)) ""))
+	 (query (or (org-protocol-convert-query-to-plist (cl-cadddr parts)) ""))
 	 (org-capture-link-is-already-stored t)) ; avoid call to org-store-link
 
     (setq org-stored-links
@@ -86,10 +87,10 @@ Pandoc, converting HTML to Org-mode."
 	 (type (if (string-match "^\\([a-z]+\\):" url)
 		   (match-string 1 url)))
 	 (title (or (string-trim (cadr parts)) ""))
-	 (content (or (string-trim (caddr parts)) ""))
+	 (content (or (string-trim (cl-caddr parts)) ""))
 	 (orglink (org-make-link-string
 		   url (if (string-match "[^[:space:]]" title) title url)))
-	 (query (or (org-protocol-convert-query-to-plist (cadddr parts)) ""))
+	 (query (or (org-protocol-convert-query-to-plist (cl-cadddr parts)) ""))
          ;; Avoid call to org-store-link
 	 (org-capture-link-is-already-stored t))
 


### PR DESCRIPTION
- Correct package header and footer
- Load libraries for using those features and byte-compile warnings
- Use cl-lib functions instead of cl.el

This PR fixes almost all byte-compile warnings.

```
In org-protocol-capture-html-with-pandoc:
org-protocol-capture-html.el:32:49:Warning: reference to free variable
    ‘org-protocol-data-separator’
org-protocol-capture-html.el:34:24:Warning: reference to free variable
    ‘org-protocol-default-template-key’
org-protocol-capture-html.el:45:11:Warning: reference to free variable
    ‘org-stored-links’
org-protocol-capture-html.el:46:34:Warning: assignment to free variable
    ‘org-stored-links’
org-protocol-capture-html.el:64:5:Warning: ‘message’ called with 1 args to
    fill 0 format field(s)
org-protocol-capture-html.el:66:15:Warning: reference to free variable
    ‘org-protocol-protocol-alist’
org-protocol-capture-html.el:66:15:Warning: assignment to free variable
    ‘org-protocol-protocol-alist’

In org-protocol-capture-readability:
org-protocol-capture-html.el:77:49:Warning: reference to free variable
    ‘org-protocol-data-separator’
org-protocol-capture-html.el:79:24:Warning: reference to free variable
    ‘org-protocol-default-template-key’
org-protocol-capture-html.el:92:34:Warning: reference to free variable
    ‘org-stored-links’
org-protocol-capture-html.el:92:34:Warning: assignment to free variable
    ‘org-stored-links’

In org-protocol-capture-html-do-capture:
org-protocol-capture-html.el:132:29:Warning: reference to free variable
    ‘template’

In end of data:
org-protocol-capture-html.el:145:1:Warning: the following functions are not known to be defin\
ed:
    org-protocol-split-data, org-protocol-sanitize-uri, string-trim,
    caddr, org-make-link-string, org-protocol-convert-query-to-plist,
    cadddr, org-store-link-props, org-demote-subtree
```
