### PR TITLE
Fix pandoc deprecation warning

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -54,7 +54,7 @@ Pandoc, converting HTML to Org-mode."
       (insert content)
       (if (not (= 0 (call-process-region
                      (point-min) (point-max)
-                     "pandoc" t t nil "--no-wrap" "-f" "html" "-t" "org")))
+                     "pandoc" t t nil "--wrap=none" "-f" "html" "-t" "org")))
           (message "Pandoc failed: " (buffer-string))
         (progn
           ;; Pandoc succeeded
@@ -110,7 +110,7 @@ Pandoc, converting HTML to Org-mode."
         (setq title (buffer-substring-no-properties (search-forward "Title:") (line-end-position)))
         (setq orglink (org-make-link-string url (if (string-match "[^[:space:]]" title) title url))))
 
-      (unless (= 0 (call-process-region (point-min) (point-max) "pandoc" t t nil "--no-wrap" "-f" "html" "-t" "org"))
+      (unless (= 0 (call-process-region (point-min) (point-max) "pandoc" t t nil "--wrap=none" "-f" "html" "-t" "org"))
         (error "Pandoc failed."))
 
       (org-store-link-props :type type


### PR DESCRIPTION
`pandoc: --no-wrap is deprecated. Use --wrap=none or --wrap=preserve instead.`

> `--wrap=[auto|none|preserve]`
> Determine how text is wrapped in the output (the source code, not the rendered version). With auto (the default), pandoc will attempt to wrap lines to the column width specified by `--columns` (default 80). With none, pandoc will not wrap lines at all. With preserve, pandoc will attempt to preserve the wrapping from the source document (that is, where there are nonsemantic newlines in the source, there will be nonsemantic newlines in the output as well).

Perhaps `--wrap=preserve` would be more appropriate instead.
WDYT?
