### PR TITLE
Fix pandoc no-wrap option detection for homebrew pandoc 1.17.2

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -25,17 +25,20 @@
   ;; --wrap=none.  Sending the wrong option causes output to STDERR,
   ;; which `call-process-region' doesn't like.  So we test Pandoc to see
   ;; which option to use.
-  (let ((process (start-process "test-pandoc" nil "pandoc" "--dump-args" "--no-wrap"))
-        (limit 3)
-        (checked 0))
+  (let* ((process (start-process "test-pandoc" "*test-pandoc*" "pandoc" "--dump-args" "--no-wrap"))
+         (buffer (process-buffer process))
+         (limit 3)
+         (checked 0))
     (while (process-live-p process)
       (if (= checked limit)
           (error "Unable to test Pandoc!  Please report this bug! (include the output of \"pandoc --dump-args --no-wrap\")")
         (sit-for 0.2)
         (incf checked)))
-    (if (= 0 (process-exit-status process))
-        "--no-wrap"
-      "--wrap=none"))
+    (with-current-buffer buffer
+      (if (and (= 0 (process-exit-status process))
+               (not (string-match "--no-wrap is deprecated" (buffer-string))))
+          "--no-wrap"
+        "--wrap=none")))
   "Option to pass to Pandoc to disable wrapping.  Pandoc >= 1.16
   deprecates `--no-wrap' in favor of `--wrap=none'.")
 


### PR DESCRIPTION
The fix in b975533 for #3 does not work for me.

* homebrew OSX pandoc 1.17.2 exits with status 0 and prints the deprecation warning if `--no-wrap` is used

* Check process output for deprecation message as well as exit status

* Tested on emacs 25.1 only, but I believe this change should work on earlier versions as well