### PR TITLE
Remove a trailing newline in urlencode

### DIFF
--- a/org-protocol-capture-html.sh
+++ b/org-protocol-capture-html.sh
@@ -47,7 +47,7 @@ EOF
 }
 
 function urlencode {
-    python -c "import sys, urllib; print urllib.quote(sys.stdin.read(), safe='')"
+    python -c "import sys, urllib; print urllib.quote(sys.stdin.read()[:-1], safe='')"
 }
 
 # * Args


### PR DESCRIPTION
It looks like `sys.stdin.read()` always gets a string ended with a newline, so I think it is safe to remove it.

I don't know python, but this solves my issue #19.