### PR TITLE
Python2-3 compatibility fixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -142,6 +142,10 @@ org-protocol-capture-html.sh -h "TODO Feed the cat!" -t i "He gets grouchy if I 
 
 * Changelog                                                      :noexport_1:
 
+** <2019-05-12>
+
++  Python 2-3 compatibility fixes in =org-protocol-capture-html.sh=.  ([[https://github.com/alphapapa/org-protocol-capture-html/pull/31][#31]].  Thanks to [[https://github.com/samspills][Sam Pillsworth]].)
+
 ** <2017-04-17>
 
 +  Use [[https://github.com/magnars/s.el][s.el]].

--- a/org-protocol-capture-html.sh
+++ b/org-protocol-capture-html.sh
@@ -48,14 +48,14 @@ EOF
 
 function urlencode {
     python -c "
+from __future__ import print_function
 try:
     from urllib import quote  # Python 2
 except ImportError:
     from urllib.parse import quote  # Python 3
+import sys
 
-import sys, urllib
-
-print urllib.quote(sys.stdin.read()[:-1], safe='')"
+print(quote(sys.stdin.read()[:-1], safe=''))"
 }
 
 # * Args


### PR DESCRIPTION
This PR fixes two compatibility issues with python3 in the `urlencode` function.

1. import `print_function` from future, and use `print()`
2. use the imported `quote` instead of `urllib.quote`