### PR TITLE
Added a way to manual add org-protocol.desktop to the mimeapps.list

### DIFF
--- a/README.org
+++ b/README.org
@@ -230,6 +230,7 @@ Then update =~/.local/share/applications/mimeinfo.cache= by running:
 -  On KDE: =kbuildsycoca4=
 -  On GNOME: =update-desktop-database ~/.local/share/applications/=
 
+Or manually adding =x-scheme-handler/org-protocol=org-protocol.desktop= to the [Added Associations] section of =~/.local/share/applications/mimeapps.list=
 *** 2. Configure Emacs
 
 **** Init file


### PR DESCRIPTION
`kbuildsycoca4` or` kbuildsycoca5` can fail due to errors in unrelated `.menu` or `.desktop` files.
 
I think it's worth mentioning that you can add `x-scheme-handler/org-protocol=org-protocol.desktop` to `~/.local/share/applications/mimeapps.list` to go around that or similar problems. 