### PR TITLE
Updating depreciated package `cl` to `cl-lib`.

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -31,7 +31,7 @@
 ;;;; Require
 
 (require 'org-protocol)
-(require 'cl)
+(require 'cl-lib)
 (require 'subr-x)
 (require 's)
 


### PR DESCRIPTION
Updating depreciated package `cl` to `cl-lib`.
Ref: https://github.com/alphapapa/org-protocol-capture-html/issues/41#issue-707497218