### PR TITLE
Add option for supplying extra arguments to pandoc.

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -47,6 +47,10 @@
 You may want to increase this if you use a sub-heading in your capture template."
   :type 'integer)
 
+(defcustom org-protocol-capture-html-pandoc-extra-args nil
+  "List of extra arguments to pass to pandoc (for example filters)."
+  :type '(repeat string))
+
 ;;;; Test Pandoc
 
 (defconst org-protocol-capture-html-pandoc-no-wrap-option nil
@@ -118,9 +122,11 @@ Pandoc, converting HTML to Org-mode."
 
     (with-temp-buffer
       (insert content)
-      (if (not (zerop (call-process-region
-                       (point-min) (point-max)
-                       "pandoc" t t nil "-f" "html" "-t" "org" org-protocol-capture-html-pandoc-no-wrap-option)))
+      (if (not (zerop (apply #'call-process-region
+                             (point-min) (point-max)
+                             "pandoc" t t nil "-f" "html" "-t" "org"
+                             org-protocol-capture-html-pandoc-no-wrap-option
+                             org-protocol-capture-html-pandoc-extra-args)))
           (message "Pandoc failed: %s" (buffer-string))
         (progn
           ;; Pandoc succeeded

--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -37,10 +37,15 @@
 
 ;;;; Vars
 
+(defgroup org-protocol-capture-html nil
+  "Capture HTML with org-protocol."
+  :group 'org-protocol
+  :group 'org)
+
 (defcustom org-protocol-capture-html-demote-times 1
   "How many times to demote headings in captured pages.
 You may want to increase this if you use a sub-heading in your capture template."
-  :group 'org-protocol-capture-html :type 'integer)
+  :type 'integer)
 
 ;;;; Test Pandoc
 


### PR DESCRIPTION
I wanted to filter away id’s and other unnecessary properties using this lua filter

```lua
function Header(el)
   el.attr = nil
   return el
end
```

and can now use `(setq org-protocol-capture-html-pandoc-extra-args '("--lua-filter=PATH/TO/pandoc-remove-header-attributes.lua"))` to do this.