### PR TITLE
Remove unnecessary dependency on cl and add cl-lib

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -1,5 +1,7 @@
 ;;; org-protocol-capture-html.el --- Capture HTML with org-protocol
 
+;; Package-Requires: ((emacs "26.1"))
+
 ;;; Commentary:
 
 ;; This package captures Web pages into Org-mode using Pandoc to
@@ -31,7 +33,7 @@
 ;;;; Require
 
 (require 'org-protocol)
-(require 'cl)
+(require 'cl-lib)
 (require 'subr-x)
 (require 's)
 


### PR DESCRIPTION
- cl was possibly needed for caddr, which is defined in subr.el since Emacs 26.1
- cl-incf from cl-lib was already used