### PR TITLE
Update function names for org 9.3

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -1,5 +1,7 @@
 ;;; org-protocol-capture-html.el --- Capture HTML with org-protocol
 
+;; Package-Requires: ((emacs "26.1"))
+
 ;;; Commentary:
 
 ;; This package captures Web pages into Org-mode using Pandoc to
@@ -31,7 +33,7 @@
 ;;;; Require
 
 (require 'org-protocol)
-(require 'cl)
+(require 'cl-lib)
 (require 'subr-x)
 (require 's)
 

--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -1,6 +1,6 @@
 ;;; org-protocol-capture-html.el --- Capture HTML with org-protocol
 
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (org "9.3"))
 
 ;;; Commentary:
 
@@ -105,7 +105,7 @@ Pandoc, converting HTML to Org-mode."
                    (match-string 1 url)))
          (title (or (org-protocol-capture-html--nbsp-to-space (string-trim (plist-get data :title))) ""))
          (content (or (org-protocol-capture-html--nbsp-to-space (string-trim (plist-get data :body))) ""))
-         (orglink (org-make-link-string
+         (orglink (org-link-make-string
                    url (if (string-match "[^[:space:]]" title) title url)))
          (org-capture-link-is-already-stored t)) ; avoid call to org-store-link
 
@@ -121,7 +121,7 @@ Pandoc, converting HTML to Org-mode."
           (message "Pandoc failed: %s" (buffer-string))
         (progn
           ;; Pandoc succeeded
-          (org-store-link-props :type type
+          (org-link-store-props :type type
                                 :annotation orglink
                                 :link url
                                 :description title
@@ -182,7 +182,7 @@ Pandoc, converting HTML to Org-mode."
                             (insert "**")
                             (end-of-line)))
                         (buffer-string)))
-             (orglink (org-make-link-string
+             (orglink (org-link-make-string
                        url (if (s-present? title) title url)))
              ;; Avoid call to org-store-link
              (org-capture-link-is-already-stored t))
@@ -191,7 +191,7 @@ Pandoc, converting HTML to Org-mode."
               (cons (list url title) org-stored-links))
         (kill-new orglink)
 
-        (org-store-link-props :type type
+        (org-link-store-props :type type
                               :annotation orglink
                               :link url
                               :description title


### PR DESCRIPTION
This applies on top of #44. These functions are only deprecated for now but works the same (compared to the updates to link-regexes done in org which have broken so many of my packages :slightly_smiling_face:), so you might not want to merge this to keep backwards compatibility.