### PR TITLE
Create customization group correctly

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -41,10 +41,15 @@
 
 ;;;; Vars
 
+(defgroup org-protocol-capture-html nil
+  "Capture HTML with org-protocol."
+  :group 'org-protocol
+  :group 'org)
+
 (defcustom org-protocol-capture-html-demote-times 1
   "How many times to demote headings in captured pages.
 You may want to increase this if you use a sub-heading in your capture template."
-  :group 'org-protocol-capture-html :type 'integer)
+  :type 'integer)
 
 ;;;; Test Pandoc
 


### PR DESCRIPTION
Groups should be created, but then doesn’t need to be stated for custom variables in the same file.