### PR TITLE
Fix pandoc "--no-wrap" option detection

### DIFF
--- a/org-protocol-capture-html.el
+++ b/org-protocol-capture-html.el
@@ -79,7 +79,9 @@ Pandoc >= 1.16 deprecates `--no-wrap' in favor of
                 (sleep-for 0.2)
                 (cl-incf checked)))
             (if (and (zerop (process-exit-status process))
-                     (not (string-match "--no-wrap is deprecated" (buffer-string))))
+                     (not (string-match
+                           (rx "--no-wrap " (or "is deprecated" "has been removed"))
+                           (buffer-string))))
                 "--no-wrap"
               "--wrap=none")))))
 


### PR DESCRIPTION
The option `--no-wrap` has removed in pandoc v2.19.2, and therefore the output of running `pandoc --no-wrap` is not `--no-wrap is deprecated`, but `--no-wrap has been removed`. This fix detects both error messages to determine whether the option should be `--no-wrap` or `--wrap=none`.